### PR TITLE
FIX: Update deprecated methods in Rails 6.0.0

### DIFF
--- a/app/jobs/yearly_review.rb
+++ b/app/jobs/yearly_review.rb
@@ -19,9 +19,12 @@ module ::Jobs
         return if Topic.where(user: Discourse.system_user, title: title).exists?
       end
 
-      view = ActionView::Base.new(ActionController::Base.view_paths, {})
+      view = ActionView::Base.new(ActionView::LookupContext.new(ActionController::Base.view_paths), {})
       view.class_eval do
         include YearlyReviewHelper
+        def compiled_method_container
+          self.class
+        end
       end
 
       review_start = Time.new(2018, 1, 1)


### PR DESCRIPTION
This fix is to solve two warnings about deprecated methods in Rails 6.0.0:
DEPRECATION WARNING: ActionView::Base instances must implement `compiled_method_container` or use the class method `with_empty_template_cache` for constructing an ActionView::Base instances that has an empty cache. 
DEPRECATION WARNING: ActionView::Base instances should be constructed with a lookup context, assignments, and a controller. 

I don't feel super confident about that, even if specs are still green and without warning