### PR TITLE
Improve email styles

### DIFF
--- a/app/jobs/yearly_review.rb
+++ b/app/jobs/yearly_review.rb
@@ -136,15 +136,15 @@ module ::Jobs
           action = row.action
           case action
           when 'likes'
-            next if row.action_count < 10
+            next if row.action_count < 0
           when 'replies'
-            next if row.action_count < 10
+            next if row.action_count < 0
           when 'bookmarks'
-            next if row.action_count < 5
+            next if row.action_count < 0
           when 'score'
-            next if row.action_count < 10
+            next if row.action_count < 0
           when 'read_time'
-            next if row.action_count < 5
+            next if row.action_count < 0
           end
           data << row
         end

--- a/app/jobs/yearly_review.rb
+++ b/app/jobs/yearly_review.rb
@@ -136,15 +136,15 @@ module ::Jobs
           action = row.action
           case action
           when 'likes'
-            next if row.action_count < 0
+            next if row.action_count < 10
           when 'replies'
-            next if row.action_count < 0
+            next if row.action_count < 10
           when 'bookmarks'
-            next if row.action_count < 0
+            next if row.action_count < 5
           when 'score'
-            next if row.action_count < 0
+            next if row.action_count < 10
           when 'read_time'
-            next if row.action_count < 0
+            next if row.action_count < 5
           end
           data << row
         end

--- a/app/jobs/yearly_review.rb
+++ b/app/jobs/yearly_review.rb
@@ -511,6 +511,7 @@ module ::Jobs
         AND t.deleted_at IS NULL
         AND p.deleted_at IS NULL
         AND p.post_type = 1
+        AND p.post_number > 1
         AND t.posts_count > 1
         AND u.id > 0
         GROUP BY t.id, topic_slug, category_slug, category_name, c.id, username, uploaded_avatar_id

--- a/app/jobs/yearly_review.rb
+++ b/app/jobs/yearly_review.rb
@@ -11,7 +11,10 @@ module ::Jobs
 
     def execute(args)
       now = Time.now
-      title = I18n.t("yearly_review.topic_title", year: now.year - 1)
+      review_year = args[:review_year] ? args[:review_year] : ::YearlyReview.last_year
+      review_start = Time.new(review_year, 1, 1)
+      review_end = review_start.end_of_year
+      title = I18n.t("yearly_review.topic_title", year: review_year)
 
       unless args[:force]
         return unless SiteSetting.yearly_review_enabled
@@ -27,11 +30,7 @@ module ::Jobs
         end
       end
 
-      review_year = args[:review_year] ? args[:review_year] : ::YearlyReview.last_year
-      review_start = Time.new(review_year, 1, 1)
-      review_end = review_start.end_of_year
-
-      raw = create_raw_topic view, review_start, review_end
+      raw = create_raw_topic view, review_year, review_start, review_end
       unless raw.empty?
         topic_opts = {
           title: title,
@@ -46,12 +45,12 @@ module ::Jobs
       end
     end
 
-    def create_raw_topic(view, review_start, review_end)
+    def create_raw_topic(view, review_year, review_start, review_end)
       review_featured_badge = SiteSetting.yearly_review_featured_badge
       user_stats = user_stats review_start, review_end
       daily_visits = daily_visits review_start, review_end
       featured_badge_users = review_featured_badge.blank? ? [] : featured_badge_users(review_featured_badge, review_start, review_end)
-      view.assign(user_stats: user_stats, daily_visits: daily_visits, featured_badge_users: featured_badge_users)
+      view.assign(review_year: review_year, user_stats: user_stats, daily_visits: daily_visits, featured_badge_users: featured_badge_users)
 
       view.render template: "yearly_review", formats: :html, layout: false
     end

--- a/app/views/yearly-review/yearly_review.html.erb
+++ b/app/views/yearly-review/yearly_review.html.erb
@@ -1,5 +1,5 @@
 <% if @user_stats.any? %>
-  <h1><%= t('yearly_review.title.users_section', year: ::YearlyReview.last_year) %></h1>
+  <h1><%= t('yearly_review.title.users_section', year: @review_year) %></h1>
   <div data-review-topic-users="true">
     <% @user_stats.each do |obj| %>
       <% if obj[:users] %>
@@ -16,8 +16,12 @@
           <% obj[:users].each_with_index do |user, i| %>
             <tr class="user-row-<%= i %>">
               <td>
-                <%= raw(avatar_image(user.username, user.uploaded_avatar_id)) %>
-                <%= raw(user_link(user.username)) %>
+                <table>
+                  <tr>
+                    <td><%= raw(avatar_image(user.username, user.uploaded_avatar_id)) %></td>
+                    <td><%= raw(user_link(user.username)) %></td>
+                  </tr>
+                </table>
               </td>
               <td>
                 <%= format_number(user.action_count < 1 ? 1 : user.action_count.round) %>
@@ -55,7 +59,7 @@
   <div data-review-users="true">
     <h2><%= t("yearly_review.title.featured_badge", badge_name: SiteSetting.yearly_review_featured_badge) %></h2>
     <% @featured_badge_users.each do |user| %>
-      <span><%= raw(avatar_image(user.username, user.uploaded_avatar_id)) %><%= raw(user_link(user.username)) %></span>
+      <span><%= raw(user_link(user.username)) %></span>
     <% end %>
     <% if @featured_badge_users[0].more_users > 0 %>
       <% @badge = @featured_badge_users[0] %>

--- a/assets/stylesheets/yearly_review.scss
+++ b/assets/stylesheets/yearly_review.scss
@@ -23,6 +23,7 @@
 
 [data-review-topic-users="true"] table table td {
   text-align: left;
+  padding-left: 0;
 }
 
 [data-review-topic-users="true"] table table td:first-child {

--- a/assets/stylesheets/yearly_review.scss
+++ b/assets/stylesheets/yearly_review.scss
@@ -12,6 +12,23 @@
   width: 50%;
 }
 
+[data-review-topic-users="true"] table table tr {
+  border-top: none;
+  border-bottom: none;
+}
+
+[data-review-topic-users="true"] table table tbody {
+  border-top: none;
+}
+
+[data-review-topic-users="true"] table table td {
+  text-align: left;
+}
+
+[data-review-topic-users="true"] table table td:first-child {
+  width: 25px;
+}
+
 [data-review-users="true"] span {
   white-space: pre;
   display: inline-block;

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -19,11 +19,6 @@ en:
       time_read: "Most Time Reading"
       most_replied_to: "Most Replied to"
       featured_badge: "Users Granted the %{badge_name} Badge"
-      most_popular_topics: "Most Popular Topics"
-      most_liked_topics: "Most Liked Topics"
-      most_liked_posts: "Most Liked Posts"
-      most_replied_to_topics: "Most Replied to Topics"
-      most_bookmarked_topics: "Most Bookmarked Topics"
     action:
       topics_created: "Topics"
       most_replied_to: "Replies"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -9,8 +9,7 @@ en:
     topic_title: "%{year}: The Year in Review"
     category_topics_title: "Top #%{category} Topics"
     title:
-      users_section: "%{year}'s top Users"
-      topics_section: "%{year}'s top Topics"
+      users_section: "%{year}'s Top Users"
       topics_created: "Most Topics"
       replies_created: "Most Replies"
       likes_given: "Most Likes Given"

--- a/plugin.rb
+++ b/plugin.rb
@@ -23,10 +23,57 @@ after_initialize do
     end
   end
 
-  ::ActionController::Base.prepend_view_path File.expand_path("../app/views/yearly-review", __FILE__)
+  ::ActionController::Base.prepend_view_path File.expand_path('../app/views/yearly-review', __FILE__)
 
   [
     '../../discourse-yearly-review/app/jobs/yearly_review.rb'
   ].each { |path| load File.expand_path(path, __FILE__) }
 
+  require_dependency 'email/styles'
+  Email::Styles.register_plugin_style do |doc|
+    doc.css('[data-review-topic-users] table').each do |element|
+      element['width'] = '100%'
+    end
+    doc.css('[data-review-featured-topics] table').each do |element|
+      element['width'] = '100%'
+    end
+
+    doc.css('[data-review-topic-users] th').each do |element|
+      element['style'] = 'text-align:left;padding-bottom:12px;'
+      element['width'] = '50%'
+    end
+    doc.css('[data-review-featured-topics] th').each do |element|
+      element['style'] = 'text-align:left;padding-bottom:12px;'
+    end
+    doc.css('[data-review-featured-topics] th:first-child').each do |element|
+      element['width'] = '10%'
+    end
+    doc.css('[data-review-featured-topics] th:nth-child(2)').each do |element|
+      element['width'] = '60%'
+    end
+    doc.css('[data-review-featured-topics] th:last-child').each do |element|
+      element['width'] = '30%'
+    end
+
+    doc.css('[data-review-topic-users] td').each do |element|
+      element['style'] = 'padding-bottom: 6px;'
+      element['valign'] = 'top'
+    end
+    doc.css('[data-review-featured-topics] td').each do |element|
+      element['style'] = 'padding-bottom: 6px;'
+      element['valign'] = 'top'
+    end
+    doc.css('[data-review-featured-topics] td:nth-child(2)').each do |element|
+      element['style'] = 'padding-bottom: 6px;padding-right:6px;'
+      element['valign'] = 'top'
+    end
+
+    doc.css('[data-review-topic-users] td table td:first-child').each do |element|
+      element['style'] = 'padding-bottom:6px;'
+        element['width'] = '25'
+    end
+    doc.css('[data-review-topic-users] td table td:nth-child(2)').each do |element|
+      element['style'] = 'padding-left:4px;padding-bottom:6px;'
+    end
+  end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -39,20 +39,20 @@ after_initialize do
     end
 
     doc.css('[data-review-topic-users] th').each do |element|
-      element['style'] = 'text-align:left;padding-bottom:12px;'
+      element['style'] = 'text-align: left;padding-bottom: 12px;'
       element['width'] = '50%'
     end
     doc.css('[data-review-featured-topics] th').each do |element|
-      element['style'] = 'text-align:left;padding-bottom:12px;'
+      element['style'] = 'text-align: left;padding-bottom: 12px;'
     end
     doc.css('[data-review-featured-topics] th:first-child').each do |element|
-      element['width'] = '10%'
+      element['width'] = '15%'
     end
     doc.css('[data-review-featured-topics] th:nth-child(2)').each do |element|
       element['width'] = '60%'
     end
     doc.css('[data-review-featured-topics] th:last-child').each do |element|
-      element['width'] = '30%'
+      element['width'] = '25%'
     end
 
     doc.css('[data-review-topic-users] td').each do |element|
@@ -63,17 +63,13 @@ after_initialize do
       element['style'] = 'padding-bottom: 6px;'
       element['valign'] = 'top'
     end
-    doc.css('[data-review-featured-topics] td:nth-child(2)').each do |element|
-      element['style'] = 'padding-bottom: 6px;padding-right:6px;'
-      element['valign'] = 'top'
-    end
 
     doc.css('[data-review-topic-users] td table td:first-child').each do |element|
-      element['style'] = 'padding-bottom:6px;'
-        element['width'] = '25'
+      element['style'] = 'padding-bottom: 6px;'
+      element['width'] = '25'
     end
     doc.css('[data-review-topic-users] td table td:nth-child(2)').each do |element|
-      element['style'] = 'padding-left:4px;padding-bottom:6px;'
+      element['style'] = 'padding-left: 4px;padding-bottom: 6px;'
     end
   end
 end


### PR DESCRIPTION
Uses the `register_plugin_style` method to inject styles and HTML elements into emails that are generated by the plugin.

Adds an inner table to align avatars with usernames in the users section.

Adds an optional `review_year` argument that can be used to generate the review topic before the year's end. (Makes it easier to develop the plugin too.)

Removes user avatars from the Badges section - they aren't needed there, and cause an issue in emails.

