### PR TITLE
FEATURE: Add option to remove user-specific stats

### DIFF
--- a/app/jobs/yearly_review.rb
+++ b/app/jobs/yearly_review.rb
@@ -49,7 +49,7 @@ module ::Jobs
       review_featured_badge = SiteSetting.yearly_review_featured_badge
       include_user_stats = SiteSetting.yearly_review_include_user_stats
 
-      user_stats = include_user_stats ? user_stats review_start, review_end : []
+      user_stats = include_user_stats ? user_stats(review_start, review_end) : []
       featured_badge_users = review_featured_badge.blank? ? [] : featured_badge_users(review_featured_badge, review_start, review_end)
       daily_visits = daily_visits review_start, review_end
       view.assign(review_year: review_year, user_stats: user_stats, daily_visits: daily_visits, featured_badge_users: featured_badge_users)

--- a/app/jobs/yearly_review.rb
+++ b/app/jobs/yearly_review.rb
@@ -47,9 +47,11 @@ module ::Jobs
 
     def create_raw_topic(view, review_year, review_start, review_end)
       review_featured_badge = SiteSetting.yearly_review_featured_badge
-      user_stats = user_stats review_start, review_end
-      daily_visits = daily_visits review_start, review_end
+      include_user_stats = SiteSetting.yearly_review_include_user_stats
+
+      user_stats = include_user_stats ? user_stats review_start, review_end : []
       featured_badge_users = review_featured_badge.blank? ? [] : featured_badge_users(review_featured_badge, review_start, review_end)
+      daily_visits = daily_visits review_start, review_end
       view.assign(review_year: review_year, user_stats: user_stats, daily_visits: daily_visits, featured_badge_users: featured_badge_users)
 
       view.render partial: 'yearly_review', layout: false

--- a/app/views/yearly-review/_yearly_review.html.erb
+++ b/app/views/yearly-review/_yearly_review.html.erb
@@ -1,6 +1,6 @@
 <% if @user_stats.any? %>
-  <h1><%= t('yearly_review.title.users_section', year: @review_year) %></h1>
   <div data-review-topic-users="true">
+    <h2><%= t('yearly_review.title.users_section', year: @review_year) %></h2>
     <% @user_stats.each do |obj| %>
       <% if obj[:users] %>
         <h2><%= t("yearly_review.title.#{obj[:key]}") %></h2>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3,6 +3,7 @@ en:
     yearly_review_enabled: "Enable the yearly review."
     yearly_review_categories: "Public categories to pull topics from. The top 5 categories from this group will be selected. If left blank will default to the top 5 public categories."
     yearly_review_exclude_staff: "Exclude Staff from user stats."
+    yearly_review_include_user_stats: "Add user-identifying stats to the first post of the review topic."
     yearly_review_publish_category: "The category the review will be published in."
     yearly_review_featured_badge: "Enter the full badge name. Can be left blank."
   yearly_review:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,6 +7,8 @@ plugins:
     default: ""
   yearly_review_exclude_staff:
     default: true
+  yearly_review_include_user_stats:
+    default: true
   yearly_review_publish_category:
     type: category
     default: ""


### PR DESCRIPTION
As requested on [Meta](https://meta.discourse.org/t/yearly-review-exclude-users-section/163633), this adds a site setting (defaulted to true) to include user statistics. Site setting can be disabled to remove user-specific stats. 

Disabling this setting still computes featured badges if enabled and daily visits.