### PR TITLE
FEATURE: Add option to include private category activity

### DIFF
--- a/app/jobs/yearly_review.rb
+++ b/app/jobs/yearly_review.rb
@@ -104,10 +104,13 @@ module ::Jobs
 
     def review_categories_from_settings
       read_restricted = SiteSetting.yearly_review_include_private_categories
+      opts = {}
+      opts[:read_restricted] = false if read_restricted == false
       if SiteSetting.yearly_review_categories.blank?
-        Category.where(read_restricted: read_restricted).order("topics_year DESC")[0, 5].pluck(:id)
+        Category.where(opts).order("topics_year DESC")[0, 5].pluck(:id)
       else
-        Category.where(read_restricted: read_restricted, id: SiteSetting.yearly_review_categories.split('|')).order("topics_year DESC").pluck(:id)
+        opts[:id] = SiteSetting.yearly_review_categories.split('|')
+        Category.where(opts).order("topics_year DESC").pluck(:id)
       end
     end
 
@@ -170,7 +173,7 @@ module ::Jobs
         ON c.id = t.category_id
         WHERE t.archetype = 'regular'
         AND ((#{!exclude_staff}) OR (u.admin = false AND u.moderator = false))
-        AND c.read_restricted = #{read_restricted}
+        #{'AND c.read_restricted = false' unless read_restricted}
         AND t.user_id > 0
         AND t.created_at >= '#{start_date}'
         AND t.created_at <= '#{end_date}'
@@ -199,7 +202,7 @@ module ::Jobs
         ON c.id = t.category_id
         WHERE t.archetype = 'regular'
         AND ((#{!exclude_staff}) OR (u.admin = false AND u.moderator = false))
-        AND c.read_restricted = #{read_restricted}
+        #{'AND c.read_restricted = false' unless read_restricted}
         AND p.user_id > 0
         AND p.post_number > 1
         AND p.post_type = 1
@@ -276,7 +279,7 @@ module ::Jobs
         ON c.id = t.category_id
         WHERE t.archetype = 'regular'
         AND ((#{!exclude_staff}) OR (u.admin = false AND u.moderator = false))
-        AND c.read_restricted = #{read_restricted}
+        #{'AND c.read_restricted = false' unless read_restricted}
         AND u.id > 0
         AND t.created_at >= '#{start_date}'
         AND t.created_at <= '#{end_date}'
@@ -306,7 +309,7 @@ module ::Jobs
         ON c.id = t.category_id
         WHERE t.archetype = 'regular'
         AND ((#{!exclude_staff}) OR (u.admin = false AND u.moderator = false))
-        AND c.read_restricted = #{read_restricted}
+        #{'AND c.read_restricted = false' unless read_restricted}
         AND u.id > 0
         AND ua.created_at >= '#{start_date}'
         AND ua.created_at <= '#{end_date}'
@@ -335,7 +338,7 @@ module ::Jobs
         ON c.id = t.category_id
         WHERE t.archetype = 'regular'
         AND ((#{!exclude_staff}) OR (u.admin = false AND u.moderator = false))
-        AND c.read_restricted = #{read_restricted}
+        #{'AND c.read_restricted = false' unless read_restricted}
         AND u.id > 0
         AND ua.created_at >= '#{start_date}'
         AND ua.created_at <= '#{end_date}'
@@ -364,7 +367,7 @@ module ::Jobs
         ON c.id = t.category_id
         WHERE t.archetype = 'regular'
         AND ((#{!exclude_staff}) OR (u.admin = false AND u.moderator = false))
-        AND c.read_restricted = #{read_restricted}
+        #{'AND c.read_restricted = false' unless read_restricted}
         AND p.created_at >= '#{start_date}'
         AND p.created_at <= '#{end_date}'
         AND p.reply_count > 0

--- a/app/jobs/yearly_review.rb
+++ b/app/jobs/yearly_review.rb
@@ -49,7 +49,7 @@ module ::Jobs
       review_featured_badge = SiteSetting.yearly_review_featured_badge
       include_user_stats = SiteSetting.yearly_review_include_user_stats
 
-      user_stats = include_user_stats ? user_stats review_start, review_end : []
+      user_stats = include_user_stats ? user_stats(review_start, review_end) : []
       featured_badge_users = review_featured_badge.blank? ? [] : featured_badge_users(review_featured_badge, review_start, review_end)
       daily_visits = daily_visits review_start, review_end
       view.assign(review_year: review_year, user_stats: user_stats, daily_visits: daily_visits, featured_badge_users: featured_badge_users)
@@ -120,7 +120,7 @@ module ::Jobs
       most_replies = most_replies review_start, review_end, exclude_staff, read_restricted
       most_likes = most_likes_given review_start, review_end, exclude_staff, read_restricted
       most_likes_received = most_likes_received review_start, review_end, exclude_staff, read_restricted
-      most_visits = most_visits review_start, review_end, exclude_staff, read_restricted
+      most_visits = most_visits review_start, review_end, exclude_staff
       most_replied_to = most_replied_to review_start, review_end, exclude_staff, read_restricted
       user_stats << { key: 'time_read', users: most_time_read } if most_time_read.any?
       user_stats << { key: 'topics_created', users: most_topics } if most_topics.any?

--- a/app/jobs/yearly_review.rb
+++ b/app/jobs/yearly_review.rb
@@ -104,11 +104,11 @@ module ::Jobs
 
     def review_categories_from_settings
       read_restricted = SiteSetting.yearly_review_include_private_categories
-      opts = {}
-      opts[:read_restricted] = false if read_restricted == false
       if SiteSetting.yearly_review_categories.blank?
-        Category.where(opts).order("topics_year DESC")[0, 5].pluck(:id)
+        Category.where(read_restricted: false).order("topics_year DESC")[0, 5].pluck(:id)
       else
+        opts = {}
+        opts[:read_restricted] = false if read_restricted == false
         opts[:id] = SiteSetting.yearly_review_categories.split('|')
         Category.where(opts).order("topics_year DESC").pluck(:id)
       end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4,6 +4,7 @@ en:
     yearly_review_categories: "Public categories to pull topics from. The top 5 categories from this group will be selected. If left blank will default to the top 5 public categories."
     yearly_review_exclude_staff: "Exclude Staff from user stats."
     yearly_review_include_user_stats: "Add user-identifying stats to the first post of the review topic."
+    yearly_review_include_private_categories: "Include user activity from private or read-restricted categories in the review."
     yearly_review_publish_category: "The category the review will be published in."
     yearly_review_featured_badge: "Enter the full badge name. Can be left blank."
   yearly_review:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,6 +9,8 @@ plugins:
     default: true
   yearly_review_include_user_stats:
     default: true
+  yearly_review_include_private_categories:
+    default: false
   yearly_review_publish_category:
     type: category
     default: ""


### PR DESCRIPTION
Earlier this year we removed private categories from the yearly review reports. However, this may not be desirable for sites that have mostly private categories and they want user stats included. This adds a setting (default: false) that when enabled includes activity in private categories.