### PR TITLE
Fix missing and typo-ed i18n keys

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -34,7 +34,8 @@ en:
         most_liked: "Most Liked"
         most_replied_to: "Most Replies"
         most_popular: "Most Popular"
-        most_boomarked: "Most Bookmarked"
+        most_bookmarked: "Most Bookmarked"
+        most_read: "Most Read"
       action_types:
         most_popular: "Score"
         most_replied_to: "Replies"


### PR DESCRIPTION
I found this when using Discourse in other language than English.
After applying this changes and setting those strings in settings in my language it translated correctly.