### PR TITLE
DEV: Compatibility with Discourse on Rails 6.1

### DIFF
--- a/app/jobs/yearly_review.rb
+++ b/app/jobs/yearly_review.rb
@@ -22,7 +22,7 @@ module ::Jobs
         return if Topic.where(user: Discourse.system_user, title: title).exists?
       end
 
-      view = ActionView::Base.new(ActionView::LookupContext.new(ActionController::Base.view_paths), {})
+      view = ActionView::Base.with_view_paths(ActionController::Base.view_paths)
       view.class_eval do
         include YearlyReviewHelper
         def compiled_method_container


### PR DESCRIPTION
Related to https://github.com/discourse/discourse/pull/12688.

Rails 6.1 changes the initializer of `ActionView::Base` to require 3 arguments. Instead of creating the instance ourselves, we can use the [`ActionView::Base.with_view_paths`](https://github.com/rails/rails/blob/c5929d5eb55b749bc124b3ccc2d79323d015701f/actionview/lib/action_view/base.rb#L229-L231) method that gives us an instance with whatever view paths we need. The `with_view_paths` method is available in Rails 6.0.3.5 (Discourse's current Rails version), so this change is backward compatible.