### PR TITLE
DEV: Remove dependence on bookmarks.topic_id

### DIFF
--- a/app/jobs/yearly_review.rb
+++ b/app/jobs/yearly_review.rb
@@ -567,7 +567,7 @@ module ::Jobs
         JOIN posts p
         ON p.id = bookmarks.post_id
         JOIN topics t
-        ON t.id = bookmarks.topic_id
+        ON t.id = p.topic_id
         JOIN categories c
         ON c.id = t.category_id
         JOIN users u

--- a/app/views/yearly-review/_yearly_review_category.html.erb
+++ b/app/views/yearly-review/_yearly_review_category.html.erb
@@ -9,7 +9,7 @@
       <th><%= t("yearly_review.rank_type.action_types.#{key}") %></th>
     </tr>
     <% val.each do |topic| %>
-    <tr>
+    <tr class="topic-<%= topic.id %>">
       <td><%= raw(avatar_image(topic.username, topic.uploaded_avatar_id)) %></td>
       <td><%= raw(topic_link(topic.title, topic.topic_slug, topic.id)) %></td>
       <td><%= format_number(topic.action_count.round) %></td>


### PR DESCRIPTION
In core PR https://github.com/discourse/discourse/pull/14289 we
are removing topic_id from the bookmarks table. This commit
pre-emptively removes the reference in this plugin.