### PR TITLE
DEV: Add discourse-compatibility for polymorphic bookmarks

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,0 +1,1 @@
+2.9.0.beta3: 3377b0d9f168eef839cb5fd0f4dcabcb3e313b4b


### PR DESCRIPTION
The commit 38d0d01e03e3bbdc2e3a660b02db4d4dffb74888 breaks
on beta and stable, this commit adds discourse-compatibility
to deal with that.