### PR TITLE
FIX: Check for existing review topic by custom field

### DIFF
--- a/spec/jobs/yearly_review_spec.rb
+++ b/spec/jobs/yearly_review_spec.rb
@@ -60,11 +60,6 @@ describe Jobs::YearlyReview do
         @yearly_review_topic = Topic.last
       end
 
-      it "doesn't publish the review topic again if it already exists with the same title" do
-        TopicCustomField.where(topic_id: @yearly_review_topic.id).destroy_all
-        expect { Jobs::YearlyReview.new.execute({}) }.not_to change { Topic.count }
-      end
-
       it "doesn't publish the review topic again if it already exists with the custom field and a different title" do
         @yearly_review_topic.update!(title: "This is a test for yearly review")
         expect { Jobs::YearlyReview.new.execute({}) }.not_to change { Topic.count }

--- a/spec/jobs/yearly_review_spec.rb
+++ b/spec/jobs/yearly_review_spec.rb
@@ -7,10 +7,12 @@ describe Jobs::YearlyReview do
     extend YearlyReviewHelper
   end
 
-  SiteSetting.yearly_review_enabled = true
+  before { SiteSetting.yearly_review_enabled = true }
+
   let(:category) { Fabricate(:category) }
   let(:top_review_user) { Fabricate(:user, username: "top_review_user") }
   let(:reviewed_user) { Fabricate(:user, username: "reviewed_user") }
+
   describe "publishing the topic" do
     describe "on January 1st" do
       before do
@@ -28,6 +30,9 @@ describe Jobs::YearlyReview do
         expect(topic.first_post.custom_fields).to eq(
           YearlyReview::POST_CUSTOM_FIELD => ::YearlyReview.last_year.to_s,
         )
+        expect(topic.custom_fields).to eq(
+          YearlyReview::POST_CUSTOM_FIELD => ::YearlyReview.last_year.to_s,
+        )
       end
     end
 
@@ -42,25 +47,27 @@ describe Jobs::YearlyReview do
       end
 
       it "doesn't publish a review topic" do
-        Jobs::YearlyReview.new.execute({})
-        topic = Topic.last
-        expect(topic.title).to eq("A topic from #{::YearlyReview.last_year}")
+        expect { Jobs::YearlyReview.new.execute({}) }.not_to change { Topic.count }
       end
     end
 
     describe "after the review has been published" do
       before do
         SiteSetting.yearly_review_publish_category = category.id
-        freeze_time DateTime.parse("#{::YearlyReview.current_year}-01-05")
+        freeze_time DateTime.parse("#{::YearlyReview.current_year}-01-01")
         Fabricate(:topic, created_at: 1.month.ago)
         Jobs::YearlyReview.new.execute({})
-        Fabricate(:topic, title: "The last topic published")
-        Jobs::YearlyReview.new.execute({})
+        @yearly_review_topic = Topic.last
       end
 
-      it "doesn't publish the review topic twice" do
-        topic = Topic.last
-        expect(topic.title).to eq("The last topic published")
+      it "doesn't publish the review topic again if it already exists with the same title" do
+        TopicCustomField.where(topic_id: @yearly_review_topic.id).destroy_all
+        expect { Jobs::YearlyReview.new.execute({}) }.not_to change { Topic.count }
+      end
+
+      it "doesn't publish the review topic again if it already exists with the custom field and a different title" do
+        @yearly_review_topic.update!(title: "This is a test for yearly review")
+        expect { Jobs::YearlyReview.new.execute({}) }.not_to change { Topic.count }
       end
     end
   end
@@ -136,7 +143,6 @@ describe Jobs::YearlyReview do
 
       before do
         SiteSetting.yearly_review_publish_category = category.id
-        SiteSetting.use_polymorphic_bookmarks = true
         10.times do
           Fabricate(:post, topic: reviewed_topic, created_at: 1.month.ago, user: top_review_user)
         end
@@ -238,6 +244,7 @@ describe Jobs::YearlyReview do
   describe "featured badge" do
     let(:admin) { Fabricate(:user, admin: true) }
     let(:badge) { Fabricate(:badge) }
+
     before do
       SiteSetting.yearly_review_featured_badge = badge.name
       SiteSetting.yearly_review_publish_category = category.id


### PR DESCRIPTION
Checking if the topic exists by name alone isn't
robust enough, if someone changes the topic title
then a new one will be created if the review job
is run again.
