### PR TITLE
FEATURE: Admin notice config reminder

### DIFF
--- a/assets/javascripts/discourse/components/yearly-review-admin-notice.gjs
+++ b/assets/javascripts/discourse/components/yearly-review-admin-notice.gjs
@@ -10,7 +10,7 @@ export function janNextYear() {
   return new Date(new Date().getFullYear() + 1, 0, 1);
 }
 
-export default class extends Component {
+export default class YearlyReviewAdminNotice extends Component {
   @service siteSettings;
 
   get toBeCreatedDate() {

--- a/assets/javascripts/discourse/components/yearly-review-admin-notice.gjs
+++ b/assets/javascripts/discourse/components/yearly-review-admin-notice.gjs
@@ -1,0 +1,29 @@
+import Component from "@glimmer/component";
+import I18n from "discourse-i18n";
+import replaceEmoji from "discourse/helpers/replace-emoji";
+import htmlSafe from "discourse-common/helpers/html-safe";
+import { inject as service } from "@ember/service";
+import i18n from "discourse-common/helpers/i18n";
+import getURL from "discourse-common/lib/get-url";
+
+export function janNextYear() {
+  return new Date(new Date().getFullYear() + 1, 0, 1);
+}
+
+export default class extends Component {
+  @service siteSettings;
+
+  get toBeCreatedDate() {
+    return moment(janNextYear()).format(I18n.t("dates.full_with_year_no_time"));
+  }
+
+  get settingsUrl() {
+    return getURL("/admin/site_settings/category/plugins?filter=plugin%3Adiscourse-yearly-review");
+  }
+
+  <template>
+    <div class="yearly-review-admin-notice alert alert-info">
+      {{replaceEmoji (htmlSafe (i18n "yearly_review.admin_notice" to_be_created_date=this.toBeCreatedDate settings_url=this.settingsUrl))}}
+    </div>
+  </template>
+ }

--- a/assets/javascripts/discourse/initializers/yearly-review-admin-notice.js
+++ b/assets/javascripts/discourse/initializers/yearly-review-admin-notice.js
@@ -1,7 +1,5 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
-import YearlyReviewAdminNotice, {
-  janNextYear,
-} from "discourse/plugins/discourse-yearly-review/discourse/components/yearly-review-admin-notice";
+import YearlyReviewAdminNotice from "discourse/plugins/discourse-yearly-review/discourse/components/yearly-review-admin-notice";
 
 export default {
   name: "yearly-review-admin-notice",
@@ -15,7 +13,7 @@ export default {
 
       // Only show this in December of the current year (getMonth is 0-based).
       const now = new Date();
-      if (janNextYear() > now && now.getMonth() === 11) {
+      if (now.getMonth() === 11) {
         api.renderInOutlet("admin-dashboard-top", YearlyReviewAdminNotice);
       }
     });

--- a/assets/javascripts/discourse/initializers/yearly-review-admin-notice.js
+++ b/assets/javascripts/discourse/initializers/yearly-review-admin-notice.js
@@ -1,0 +1,23 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+import YearlyReviewAdminNotice, {
+  janNextYear,
+} from "discourse/plugins/discourse-yearly-review/discourse/components/yearly-review-admin-notice";
+
+export default {
+  name: "yearly-review-admin-notice",
+  initialize(container) {
+    withPluginApi("1.18.0", (api) => {
+      const siteSettings = container.lookup("service:site-settings");
+
+      if (!siteSettings.yearly_review_enabled) {
+        return;
+      }
+
+      // Only show this in December of the current year (getMonth is 0-based).
+      const now = new Date();
+      if (janNextYear() > now && now.getMonth() === 11) {
+        api.renderInOutlet("admin-dashboard-top", YearlyReviewAdminNotice);
+      }
+    });
+  },
+};

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,0 +1,5 @@
+en:
+  js:
+    yearly_review:
+      admin_notice: "The Yearly Review topic will be created soon on %{to_be_created_date}. Please <a href='%{settings_url}'>review the settings now</a> and be sure to set the yearly review publish category to the staff or other private category so you can view it before making it public, and maybe add a celebratory note! :partying_face: <a target='_blank' rel='noopener noreferrer' href='https://meta.discourse.org/t/discourse-yearly-review/105713'>More details...</a>"
+

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,5 +1,5 @@
 en:
   js:
     yearly_review:
-      admin_notice: "The Yearly Review topic will be created soon on %{to_be_created_date}. Please <a href='%{settings_url}'>review the settings now</a> and be sure to set the yearly review publish category to the staff or other private category so you can view it before making it public, and maybe add a celebratory note! :partying_face: <a target='_blank' rel='noopener noreferrer' href='https://meta.discourse.org/t/discourse-yearly-review/105713'>More details...</a>"
+      admin_notice: "The Yearly Review topic will be created soon on %{to_be_created_date}. Please <a href='%{settings_url}'>review the settings now</a> and be sure to set the yearly review publish category to the staff or other private category so you can view it before making it public, and maybe add a celebratory note! :partying_face: <a target='_blank' rel='noopener noreferrer' href='https://meta.discourse.org/t/discourse-yearly-review/105713'>More details…</a>"
 


### PR DESCRIPTION
This adds a reminder at the top of the admin dashboard
only in December that reminds them to configure the yearly
review plugin before it is run on January 1.

![image](https://github.com/discourse/discourse-yearly-review/assets/920448/1c11e085-de22-4775-8974-d3a536274c4c)

