### PR TITLE
FIX: Fixes topic creation double-ups

### DIFF
--- a/app/jobs/yearly_review.rb
+++ b/app/jobs/yearly_review.rb
@@ -625,10 +625,13 @@ module ::Jobs
     end
 
     def review_topic_exists?(review_year)
-      TopicCustomField
-        .find_by(name: ::YearlyReview::POST_CUSTOM_FIELD, value: review_year.to_s)
-        &.topic
-        .present?
+      TopicCustomField.joins(:topic).exists?(
+        name: ::YearlyReview::POST_CUSTOM_FIELD,
+        value: review_year.to_s,
+        topic: {
+          deleted_at: nil,
+        },
+      )
     end
   end
 end

--- a/spec/jobs/yearly_review_spec.rb
+++ b/spec/jobs/yearly_review_spec.rb
@@ -64,6 +64,17 @@ describe Jobs::YearlyReview do
         @yearly_review_topic.update!(title: "This is a test for yearly review")
         expect { Jobs::YearlyReview.new.execute({}) }.not_to change { Topic.count }
       end
+
+      it "doesn't publish the review topic again if it already exists and a previous version was deleted" do
+        @yearly_review_topic.trash!
+        expect { Jobs::YearlyReview.new.execute({}) }.to change { Topic.count }
+        expect { Jobs::YearlyReview.new.execute({}) }.not_to change { Topic.count }
+      end
+
+      it "doesn't publish the review topic again if it already exists and has been moved to another category" do
+        @yearly_review_topic.update!(category: Fabricate(:category))
+        expect { Jobs::YearlyReview.new.execute({}) }.not_to change { Topic.count }
+      end
     end
   end
 


### PR DESCRIPTION
Followup to 98012d8c923c9c9ad0028e3c8c44fffc13556ea6,
if the first review topic for the year is deleted, then
that was permanently affecting this check and making it
incorrect, leading to the yearly review topic being created
as many times as the sidekiq job was run. This is because
the find_by method was finding the first topic custom field,
which would always have a deleted topic and always be null.

Now we filter the check and make it so it doesn't include
deleted topics.
